### PR TITLE
Prevent fatal error because of generated class contract incompatibility

### DIFF
--- a/protoc-gen-twirp_php/templates/global/TwirpError.php
+++ b/protoc-gen-twirp_php/templates/global/TwirpError.php
@@ -49,7 +49,7 @@ final class TwirpError extends \Exception implements Error
     /**
      * {@inheritdoc}
      */
-    public function getMeta($key): string
+    public function getMeta(string $key): string
     {
         if (isset($this->meta[$key])) {
             return $this->meta[$key];


### PR DESCRIPTION
Applies for php 7.1+
Otherwise generated class throw
```
Fatal error: Declaration of ...TwirpError::getMeta($key): string must be compatible with Twirp\Error::getMeta(string $key): string
